### PR TITLE
Make lookup case-insensitive

### DIFF
--- a/lib/language_list.rb
+++ b/lib/language_list.rb
@@ -48,10 +48,11 @@ module LanguageList
     end
 
     def self.find_by_name(name)
-      LanguageList::BY_NAME[name]
+      LanguageList::BY_NAME[name.downcase]
     end
 
     def self.find(code)
+      code.downcase!
       find_by_iso_639_1(code) || find_by_iso_639_3(code) || find_by_name(code)
     end
   end
@@ -71,7 +72,7 @@ module LanguageList
   BY_ISO_639_1 = {}
   BY_ISO_639_3 = {}
   ALL_LANGUAGES.each do |lang|
-    BY_NAME[lang.name] = lang
+    BY_NAME[lang.name.downcase] = lang
     BY_ISO_639_1[lang.iso_639_1] = lang if lang.iso_639_1
     BY_ISO_639_3[lang.iso_639_3] = lang if lang.iso_639_3
   end

--- a/test/language_list_test.rb
+++ b/test/language_list_test.rb
@@ -39,6 +39,13 @@ class LanguageListTest < Minitest::Test
     assert_equal 'English', english.name
   end
 
+  def test_case_insensitive_find_by_name
+    english = LanguageList::LanguageInfo.find_by_name('english')
+    assert_equal 'en', english.iso_639_1
+    assert_equal 'eng', english.iso_639_3
+    assert_equal 'English', english.name
+  end
+
   def test_find_with_iso_639_1_code
     english = LanguageList::LanguageInfo.find('en')
     assert_equal 'en', english.iso_639_1
@@ -46,8 +53,22 @@ class LanguageListTest < Minitest::Test
     assert_equal 'English', english.name
   end
 
+  def test_case_insensitive_find_with_iso_639_1_code
+    english = LanguageList::LanguageInfo.find('EN')
+    assert_equal 'en', english.iso_639_1
+    assert_equal 'eng', english.iso_639_3
+    assert_equal 'English', english.name
+  end
+
   def test_find_with_iso_639_3_code
     english = LanguageList::LanguageInfo.find('eng')
+    assert_equal 'en', english.iso_639_1
+    assert_equal 'eng', english.iso_639_3
+    assert_equal 'English', english.name
+  end
+
+  def test_case_insensitive_find_with_iso_639_3_code
+    english = LanguageList::LanguageInfo.find('Eng')
     assert_equal 'en', english.iso_639_1
     assert_equal 'eng', english.iso_639_3
     assert_equal 'English', english.name


### PR DESCRIPTION
What it says on the tin.

For my use case I have little control over inputs, and the fact that finding by code expects a lowercase input while finding by name expects a properly capitalized input complicates things. This change enables `LanguageList::LanguageInfo.find` to return the correct result regardless of input case.

This introduces no ambiguity as there are no language codes or names currently included that are differentiated only by case.

Tests pass, and I added a couple demonstrating case-insensitive lookup.