### PR TITLE
Fix .find modifies string which is an issue for frozen strings

### DIFF
--- a/lib/language_list.rb
+++ b/lib/language_list.rb
@@ -62,7 +62,7 @@ module LanguageList
     end
 
     def self.find(code)
-      code.downcase!
+      code = code.downcase
       find_by_iso_639_1(code) ||
         find_by_iso_639_3(code) ||
         find_by_iso_639_2b(code) ||

--- a/lib/language_list.rb
+++ b/lib/language_list.rb
@@ -58,10 +58,14 @@ module LanguageList
     end
 
     def self.find_by_name(name)
+      return if name.nil?
+      
       LanguageList::BY_NAME[name.downcase]
     end
 
     def self.find(code)
+      return if code.nil?
+      
       code = code.downcase
       find_by_iso_639_1(code) ||
         find_by_iso_639_3(code) ||

--- a/test/language_list_test.rb
+++ b/test/language_list_test.rb
@@ -36,7 +36,7 @@ class LanguageListTest < Minitest::Test
   end
 
   def test_find_by_iso_639_1_with_frozen_string
-    english = LanguageList::LanguageInfo.find_by_iso_639_1('en'.frozen)
+    english = LanguageList::LanguageInfo.find_by_iso_639_1('en'.freeze)
     assert_equal 'en', english.iso_639_1
     assert_equal 'eng', english.iso_639_3
     assert_equal 'English', english.name
@@ -60,7 +60,7 @@ class LanguageListTest < Minitest::Test
   end
 
   def test_find_by_iso_639_3_with_frozen_string
-    english = LanguageList::LanguageInfo.find_by_iso_639_3('eng'.frozen)
+    english = LanguageList::LanguageInfo.find_by_iso_639_3('eng'.freeze)
     assert_equal 'en', english.iso_639_1
     assert_equal 'eng', english.iso_639_3
     assert_equal 'English', english.name
@@ -77,7 +77,7 @@ class LanguageListTest < Minitest::Test
   end
 
   def test_find_by_name_with_frozen_string
-    english = LanguageList::LanguageInfo.find_by_name('English'.frozen)
+    english = LanguageList::LanguageInfo.find_by_name('English'.freeze)
     assert_equal 'en', english.iso_639_1
     assert_equal 'eng', english.iso_639_3
     assert_equal 'eng', english.iso_639_2b
@@ -112,7 +112,7 @@ class LanguageListTest < Minitest::Test
   end
 
   def test_find_with_frozen_string
-    english = LanguageList::LanguageInfo.find('EN'.frozen)
+    english = LanguageList::LanguageInfo.find('EN'.freeze)
     assert_equal 'en', english.iso_639_1
     assert_equal 'eng', english.iso_639_3
     assert_equal 'English', english.name

--- a/test/language_list_test.rb
+++ b/test/language_list_test.rb
@@ -25,10 +25,63 @@ class LanguageListTest < Minitest::Test
     assert_equal 'English', english.name
   end
 
+  def test_find_by_iso_639_1_with_nil
+    result = LanguageList::LanguageInfo.find_by_iso_639_1(nil)
+    assert_equal nil, result
+  end
+
+  def test_find_by_iso_639_1_with_empty_string
+    result = LanguageList::LanguageInfo.find_by_iso_639_1('')
+    assert_equal nil, result
+  end
+
+  def test_find_by_iso_639_1_with_frozen_string
+    english = LanguageList::LanguageInfo.find_by_iso_639_1('en'.frozen)
+    assert_equal 'en', english.iso_639_1
+    assert_equal 'eng', english.iso_639_3
+    assert_equal 'English', english.name
+  end
+
   def test_find_by_iso_639_3
     english = LanguageList::LanguageInfo.find_by_iso_639_3('eng')
     assert_equal 'en', english.iso_639_1
     assert_equal 'eng', english.iso_639_3
+    assert_equal 'English', english.name
+  end
+
+  def test_find_by_iso_639_3_with_nil
+    result = LanguageList::LanguageInfo.find_by_iso_639_3(nil)
+    assert_equal nil, result
+  end
+
+  def test_find_by_iso_639_3_with_empty_string
+    result = LanguageList::LanguageInfo.find_by_iso_639_3('')
+    assert_equal nil, result
+  end
+
+  def test_find_by_iso_639_3_with_frozen_string
+    english = LanguageList::LanguageInfo.find_by_iso_639_3('eng'.frozen)
+    assert_equal 'en', english.iso_639_1
+    assert_equal 'eng', english.iso_639_3
+    assert_equal 'English', english.name
+  end
+
+  def test_find_by_name_with_nil
+    result = LanguageList::LanguageInfo.find_by_name(nil)
+    assert_equal nil, result
+  end
+
+  def test_find_by_name_with_empty_string
+    result = LanguageList::LanguageInfo.find_by_name('')
+    assert_equal nil, result
+  end
+
+  def test_find_by_name_with_frozen_string
+    english = LanguageList::LanguageInfo.find_by_name('English'.frozen)
+    assert_equal 'en', english.iso_639_1
+    assert_equal 'eng', english.iso_639_3
+    assert_equal 'eng', english.iso_639_2b
+    assert_equal 'eng', english.iso_639_2t
     assert_equal 'English', english.name
   end
 
@@ -43,6 +96,23 @@ class LanguageListTest < Minitest::Test
 
   def test_case_insensitive_find_by_name
     english = LanguageList::LanguageInfo.find_by_name('english')
+    assert_equal 'en', english.iso_639_1
+    assert_equal 'eng', english.iso_639_3
+    assert_equal 'English', english.name
+  end
+
+  def test_find_with_nil
+    result = LanguageList::LanguageInfo.find(nil)
+    assert_equal nil, result
+  end
+
+  def test_find_with_empty_string
+    result = LanguageList::LanguageInfo.find('')
+    assert_equal nil, result
+  end
+
+  def test_find_with_frozen_string
+    english = LanguageList::LanguageInfo.find('EN'.frozen)
     assert_equal 'en', english.iso_639_1
     assert_equal 'eng', english.iso_639_3
     assert_equal 'English', english.name


### PR DESCRIPTION
Ruby allows to globally freeze strings.

https://github.com/scsmith/language_list/blob/d89d4ce6d852d18595b551cd33edafe1b93e3238/lib/language_list.rb#L65

would lead to the `can't modify frozen String` error.
This PR creates a copy of the string and modifies this
