### PR TITLE
Include common names in the BY_NAME hash

### DIFF
--- a/lib/language_list.rb
+++ b/lib/language_list.rb
@@ -93,6 +93,7 @@ module LanguageList
   BY_ISO_639_2T = {}
   ALL_LANGUAGES.each do |lang|
     BY_NAME[lang.name.downcase] = lang
+    BY_NAME[lang.common_name.downcase] = lang if lang.common_name
     BY_ISO_639_1[lang.iso_639_1] = lang if lang.iso_639_1
     BY_ISO_639_3[lang.iso_639_3] = lang if lang.iso_639_3
     BY_ISO_639_2B[lang.iso_639_2b] = lang if lang.iso_639_2b

--- a/test/language_list_test.rb
+++ b/test/language_list_test.rb
@@ -94,6 +94,15 @@ class LanguageListTest < Minitest::Test
     assert_equal 'English', english.name
   end
 
+  def test_find_by_common_name
+    greek = LanguageList::LanguageInfo.find_by_name('greek')
+    assert_equal 'el', greek.iso_639_1
+    assert_equal 'ell', greek.iso_639_3
+    assert_equal 'gre', greek.iso_639_2b
+    assert_equal 'ell', greek.iso_639_2t
+    assert_equal 'Greek', greek.common_name
+  end
+
   def test_case_insensitive_find_by_name
     english = LanguageList::LanguageInfo.find_by_name('english')
     assert_equal 'en', english.iso_639_1


### PR DESCRIPTION
Adds down-cased common_name's to the name search hash.

This fixes issues where queries like `LanguageList::LanguageInfo.find('greek')` don't work because the common names aren't being searched.

Related to https://github.com/scsmith/language_list/issues/24